### PR TITLE
Fix NameError on self-referential Timetable annotation (Python <3.14)

### DIFF
--- a/src/timetable/timetable.py
+++ b/src/timetable/timetable.py
@@ -4,6 +4,8 @@
 """ A class for timetable of a day """
 
 # Libraries
+from __future__ import annotations
+
 from copy import copy
 from datetime import time
 from typing import Any


### PR DESCRIPTION
## Problem

Running any entry point that imports `src.timetable.timetable` fails at import time on Python 3.10–3.13:

```
File "src/timetable/timetable.py", line 84, in Timetable
    def __copy__(self) -> Timetable:
         ^^^^^^^^^
NameError: name 'Timetable' is not defined
```

Reproduced with:

```
python3 -m src.routing_pk.main
```

## Root cause

`Timetable.__copy__` has the return annotation `-> Timetable`, which references the enclosing class. Annotations are evaluated at class-definition time, before the `Timetable` name is bound in the enclosing scope, so the lookup fails.

This happens to work on Python 3.14+ because PEP 649 made annotation evaluation deferred by default, but the README targets Python 3.10+, where the annotation must be made lazy explicitly.

## Fix

Add `from __future__ import annotations` (PEP 563) at the top of `src/timetable/timetable.py`. This turns all annotations in the module into strings evaluated lazily, which resolves the forward reference without any runtime behavior change.

A `-> "Timetable"` string literal would also work, but the `__future__` import is consistent with common practice and covers any future self-references added to the module.

## Verification

```
$ python3 -c "from src.timetable.timetable import Timetable; print('ok')"
ok
```
