### PR TITLE
补充“复兴门”、“建国门”可逆行换乘时间

### DIFF
--- a/data/beijing/metadata.json5
+++ b/data/beijing/metadata.json5
@@ -10,7 +10,7 @@
             // 节点2->1, 早晚可逆行
             {
                 from: "1号线", to: "2号线", minutes: 1, distance: 0, stairs: 37,
-                apply_time: [{end: "06:30"}, {start: "20:30"}]
+                apply_time: [{date_group: "工作日", end: "07:20"}, {date_group: "工作日", start: "09:20", end: "16:30"}, {date_group: "工作日", start: "20:00"}, {date_group: "双休日"}]
             }
         ],
         "建国门": [
@@ -19,7 +19,7 @@
             // 节点2->1, 非高峰可逆行
             {
                 from: "1号线", to: "2号线", minutes: 1, distance: 0, stairs: 38,
-                apply_time: [{end: "07:00"}, {start: "09:30", end: "16:30"}, {start: "19:00"}]
+                apply_time: apply_time: [{date_group: "工作日", end: "07:30"}, {date_group: "工作日", start: "09:30", end: "17:00"}, {date_group: "工作日", start: "19:00"}, {date_group: "双休日"}]
             }
         ],
         // 参考：https://www.bilibili.com/video/BV1jMqRY2EZm

--- a/data/beijing/metadata.json5
+++ b/data/beijing/metadata.json5
@@ -19,7 +19,7 @@
             // 节点2->1, 非高峰可逆行
             {
                 from: "1号线", to: "2号线", minutes: 1, distance: 0, stairs: 38,
-                apply_time: apply_time: [{date_group: "工作日", end: "07:30"}, {date_group: "工作日", start: "09:30", end: "17:00"}, {date_group: "工作日", start: "19:00"}, {date_group: "双休日"}]
+                apply_time: [{date_group: "工作日", end: "07:30"}, {date_group: "工作日", start: "09:30", end: "17:00"}, {date_group: "工作日", start: "19:00"}, {date_group: "双休日"}]
             }
         ],
         // 参考：https://www.bilibili.com/video/BV1jMqRY2EZm


### PR DESCRIPTION
补充“复兴门”、“建国门”可逆行换乘时间
具体参考如图
复兴门
<img width="1024" height="641" alt="复兴门1- 2" src="https://github.com/user-attachments/assets/82acb181-1bc1-4a89-b8da-be39b6df370f" />
建国门
<img width="1022" height="667" alt="建国门1- 2" src="https://github.com/user-attachments/assets/648fbe4b-9b89-4989-8912-5e4c717da750" />



